### PR TITLE
Fix for #10078 (ampersand symbol "&" is not escaped in link URL)

### DIFF
--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -176,7 +176,7 @@ export class TableRenderer {
       var scopedVars = this.renderRowVariables(rowIndex);
       scopedVars['__cell'] = { value: value };
 
-      var cellLink = this.templateSrv.replace(column.style.linkUrl, scopedVars);
+      var cellLink = this.templateSrv.replace(column.style.linkUrl, scopedVars, encodeURIComponent);
       var cellLinkTooltip = this.templateSrv.replace(column.style.linkTooltip, scopedVars);
       var cellTarget = column.style.linkTargetBlank ? '_blank' : '';
 


### PR DESCRIPTION
Fix for #10078, Render value as link in Table panel: ampersand symbol "&" is not escaped in link URL, resulting URL is wrong.

